### PR TITLE
do not allocate terminal when doing ssh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,4 +4,4 @@
 find src -name "*.egg-info" | xargs rm -rf
 rm -rf build
 rm -rf dist
-python setup.py sdist bdist_wheel --universal
+python setup.py sdist bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(HERE, "README.md"), "r") as f:
 # This call to setup() does all the work
 setup(
     name="spark-etl",
-    version="0.0.5",
+    version="0.0.6",
     description="Generic ETL Pipeline Framework for Apache Spark",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -21,7 +21,6 @@ setup(
     license="MIT",
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
     ],
     package_dir = {'': 'src'},

--- a/src/spark_etl/job_submitters/livy_job_submitter.py
+++ b/src/spark_etl/job_submitters/livy_job_submitter.py
@@ -12,7 +12,7 @@ import requests
 from .abstract_job_submitter import AbstractJobSubmitter
 
 def _execute(host, cmd, error_ok=False):
-    r = subprocess.call(["ssh", "-q", "-t", host, cmd], shell=False)
+    r = subprocess.call(["ssh", "-q", host, cmd], shell=False)
     if not error_ok and r != 0:
         raise Exception(f"command {cmd} failed with exit code {r}")
 


### PR DESCRIPTION
1. Do not specify -t option when doing ssh, so this tool can be called in pure batch system even without terminal
2. bump version as we have changes
3. Remove support for python2 (python2 is officially expired at the end of 2019)
